### PR TITLE
meson: add ability to configure libsrtp2 crypto library (defaulting to mbedtls)

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -9,7 +9,7 @@ DOCKER_REPOSITORY = "livepeerci/mistserver"
 
 DOCKER_BUILDS = {
     "arch": ["amd64", "arm64"],
-    "release": ["static", "shared"],
+    "release": ["static"],
     "strip": ["true", "false"],
 }
 

--- a/.drone.star
+++ b/.drone.star
@@ -87,7 +87,7 @@ def docker_image_pipeline(arch, release, stripped, context):
             {
                 "name": "build",
                 "commands": [
-                    "docker buildx build --progress=plain --target=mist "
+                    "docker buildx build --no-cache --progress=plain --target=mist "
                     + "--build-arg BUILD_TARGET={} --build-arg STRIP_BINARIES={} --build-arg BUILD_VERSION={} --tag {} ".format(
                         release,
                         stripped,

--- a/meson.build
+++ b/meson.build
@@ -133,7 +133,7 @@ if usessl
   endif
 
   mist_deps += [mbedtls, mbedx509, mbedcrypto]
-  mist_deps += dependency('libsrtp2', default_options: ['tests=disabled'], fallback: ['libsrtp2', 'libsrtp2_dep'])
+  mist_deps += dependency('libsrtp2', default_options: ['tests=disabled', 'crypto-library=' + get_option('SRTP_CRYPTO_LIBRARY')], fallback: ['libsrtp2', 'libsrtp2_dep'])
 endif
 
 libsrt = false

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,4 +24,4 @@ option('WITH_JPG', description: 'Build JPG thumbnailer output support (WIP)', ty
 option('WITH_SANITY', description: 'Enable MistOutSanityCheck output for testing purposes', type: 'boolean', value: false)
 option('LSP_MINIFY', description: 'Try to minify LSP JS via java closure-compiler, generally not needed unless changing JS code as a minified version is part of the repository already', type: 'boolean', value: false)
 option('LOCAL_GENERATORS', description: 'Attempts to find a locally-installed version of sourcery and make_html, instead of compiling it', type: 'boolean', value: false)
-
+option('SRTP_CRYPTO_LIBRARY', type: 'combo', choices : ['none', 'openssl', 'nss', 'mbedtls'], value : 'mbedtls', description : 'What external crypto library to leverage for libsrtp2, if any (OpenSSL, NSS, or mbedtls)')

--- a/subprojects/libsrtp2.wrap
+++ b/subprojects/libsrtp2.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 directory = libsrtp
 url = https://github.com/cisco/libsrtp.git
-revision = 1b6deccb216e3cd88bf7ce563b34557b3897c2dd
+revision = 944b0e79daa5737fe150c4da1aacd3d3bc14539b
 
 [provide]
 libsrtp2 = libsrtp2_dep


### PR DESCRIPTION
This was upstreamed to cisco/libsrtp2 so now it's very easy. https://github.com/cisco/libsrtp/pull/660

Preliminary testing showed similar performance for OpenSSL and mbedtls, and mbedtls is already a Meson subproject, so we may as well just use this. Both OpenSSL and mbedtls were around twice as performant as the built-in libsrtp2 crypto functions.