### PR TITLE
util_load: allow debug logs to be turned on/off

### DIFF
--- a/src/utils/util_load.cpp
+++ b/src/utils/util_load.cpp
@@ -228,7 +228,7 @@ public:
   }
   /// Scores a potential new connection to this server
   /// 0 means not possible, the higher the better.
-  uint64_t rate(std::string &s, double lati = 0, double longi = 0, const std::map<std::string, int32_t> &tagAdjust = blankTags, uint8_t dbg){
+  uint64_t rate(std::string &s, double lati = 0, double longi = 0, const std::map<std::string, int32_t> &tagAdjust = blankTags, uint8_t dbg = 0){
     if (!hostMutex){hostMutex = new tthread::mutex();}
     tthread::lock_guard<tthread::mutex> guard(*hostMutex);
     if (!ramMax || !availBandwidth){
@@ -731,7 +731,7 @@ int handleRequest(Socket::Connection &conn){
             }
           }
         }
-        if (host.debug()){
+        if (debug.size()){
           for (HOSTLOOP){
             if (hosts[i].state == STATE_OFF){continue;}
             hosts[i].debug = 1;
@@ -789,7 +789,7 @@ int handleRequest(Socket::Connection &conn){
       uint64_t bestScore = 0;
       for (HOSTLOOP){
         HOSTCHECK;
-        uint8_t debugEnable = HOST(i).debug
+        uint8_t debugEnable = HOST(i).debug;
         uint64_t score = HOST(i).details->rate(stream, lat, lon, tagAdjust, debugEnable);
         if (score > bestScore){
           bestHost = &HOST(i);

--- a/src/utils/util_load.cpp
+++ b/src/utils/util_load.cpp
@@ -228,7 +228,7 @@ public:
   }
   /// Scores a potential new connection to this server
   /// 0 means not possible, the higher the better.
-  uint64_t rate(std::string &s, double lati = 0, double longi = 0, const std::map<std::string, int32_t> &tagAdjust = blankTags){
+  uint64_t rate(std::string &s, double lati = 0, double longi = 0, const std::map<std::string, int32_t> &tagAdjust = blankTags, uint8_t dbg){
     if (!hostMutex){hostMutex = new tthread::mutex();}
     tthread::lock_guard<tthread::mutex> guard(*hostMutex);
     if (!ramMax || !availBandwidth){
@@ -266,10 +266,17 @@ public:
       score = 0;
     }
     // Print info on host
-    MEDIUM_MSG("%s: CPU %" PRIu64 ", RAM %" PRIu64 ", Stream %zu, BW %" PRIu64
+    if (dbg) {
+      INFO_MSG("%s (%s) CPU %" PRIu64 ", RAM %" PRIu64 ", Stream %zu, BW %" PRIu64
+               " (max %" PRIu64 " MB/s), Geo %" PRIu64 ", tag adjustment %" PRId64 " -> %" PRIu64,
+               host.c_str(), s.c_str(), cpu_score, ram_score, streams.count(s) ? weight_bonus : (size_t)0, bw_score,
+               availBandwidth / 1024 / 1024, geo_score, adjustment, score);
+    } else {
+      MEDIUM_MSG("%s: CPU %" PRIu64 ", RAM %" PRIu64 ", Stream %zu, BW %" PRIu64
                " (max %" PRIu64 " MB/s), Geo %" PRIu64 ", tag adjustment %" PRId64 " -> %" PRIu64,
                host.c_str(), cpu_score, ram_score, streams.count(s) ? weight_bonus : (size_t)0, bw_score,
                availBandwidth / 1024 / 1024, geo_score, adjustment, score);
+    }
     return score;
   }
   /// Scores this server as a source
@@ -441,6 +448,7 @@ struct hostEntry{
   char name[HOSTNAMELEN];          // host+port for server
   hostDetails *details;    /// hostDetails pointer
   tthread::thread *thread; /// thread pointer
+  uint8_t debug; // 0 = off, 1 = on (used for verbose debug logs)
 };
 
 hostEntry hosts[MAXHOSTS]; /// Fixed-size array holding all hosts
@@ -480,6 +488,7 @@ int handleRequest(Socket::Connection &conn){
         std::string addserver = H.GetVar("addserver");
         std::string delserver = H.GetVar("delserver");
         std::string weights = H.GetVar("weights");
+        std::string debug = H.GetVar("debug");
         H.Clean();
         H.SetHeader("Content-Type", "text/plain");
         JSON::Value ret;
@@ -722,6 +731,21 @@ int handleRequest(Socket::Connection &conn){
             }
           }
         }
+        if (host.debug()){
+          for (HOSTLOOP){
+            if (hosts[i].state == STATE_OFF){continue;}
+            hosts[i].debug = 1;
+            ret = hosts[i].debug;
+            HOSTCHECK;
+          }
+        }else{
+          for (HOSTLOOP){
+            if (hosts[i].state == STATE_OFF){continue;}
+            hosts[i].debug = 0;
+            ret = hosts[i].debug;
+            HOSTCHECK;
+          }
+        }
         H.SetBody(ret.toPrettyString());
         H.setCORSHeaders();
         H.SendResponse("200", "OK", conn);
@@ -765,7 +789,8 @@ int handleRequest(Socket::Connection &conn){
       uint64_t bestScore = 0;
       for (HOSTLOOP){
         HOSTCHECK;
-        uint64_t score = HOST(i).details->rate(stream, lat, lon, tagAdjust);
+        uint8_t debugEnable = HOST(i).debug
+        uint64_t score = HOST(i).details->rate(stream, lat, lon, tagAdjust, debugEnable);
         if (score > bestScore){
           bestHost = &HOST(i);
           bestScore = score;


### PR DESCRIPTION
Some verbose logs are noisy and only required temporarily when live debugging a node. Add option to turn some of these logs on/off when required.